### PR TITLE
Fix various nits in `docs/software-development-kits/dotnetcore.mdx`

### DIFF
--- a/docs/software-development-kits/dotnetcore.mdx
+++ b/docs/software-development-kits/dotnetcore.mdx
@@ -8,7 +8,7 @@ Aserto Authorization middleware for ASP.NET core.
 
 ## Overview
 
-This package provides allows .NET ASP applications to use Aserto as the Authorization provider.
+This package allows ASP.NET applications to use Aserto as the Authorization provider.
 
 ## Installation
 
@@ -26,6 +26,7 @@ dotnet add package Aserto.AspNetCore.Middleware
 ```
 
 ## Configuration
+
 The following configuration settings are required for Aserto.AspNetCore middleware. You can add them to your `appsettings.json`:
 ```json
 // appsettings.json
@@ -37,17 +38,18 @@ The following configuration settings are required for Aserto.AspNetCore middlewa
     "PolicyRoot": "YOUR_POLICY_ROOT"
 }
 ``` 
-This settings can be retrieved from the [Policy Settings](https://console.aserto.com/ui/policies) page of your Aserto account.
+These settings can be retrieved from the [Policy Settings](https://console.aserto.com/ui/policies) page of your Aserto account.
 
 The middleware accepts the following optional parameters:
 
 | Parameter name | Default value | Description |
 | -------------- | ------------- | ----------- |
-| Enabled | true | Enables or disables Aserto Authorization |
+| Enabled | true | Enables or disables Aserto Authorization. |
 | ServiceUrl | "https://authorizer.prod.aserto.com:8443" | Sets the URL for the authorizer endpoint. |
 | Decision | "allowed" | The decision that will be used by the middleware when creating an authorizer request. |
 
 ### Identity
+
 To determine the identity of the user, the middleware checks the following Claim types:
 
 | Name | Description | URI |
@@ -56,30 +58,30 @@ To determine the identity of the user, the middleware checks the following Claim
 | Name | The unique name of the user | http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name |
 | Name Identifier | The SAML name identifier of the user | http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier |
 
-These can be overwritten by passing other claim types to the `AsertoDecisionRequirement`:
-
+These can be overwritten by passing other Claim types to the `AsertoDecisionRequirement`:
 ```csharp
 // Startup.cs
 
-    public void ConfigureServices(IServiceCollection services)
-    {
-        //..
+public void ConfigureServices(IServiceCollection services)
+{
+    //..
 
-        services.AddAuthorization(options =>
+    services.AddAuthorization(options =>
+    {
+        options.AddPolicy("Aserto", policy =>
+        policy.Requirements.Add(new AsertoDecisionRequirement(new List<string>
         {
-            options.AddPolicy("Aserto", policy => 
-            policy.Requirements.Add(new AsertoDecisionRequirement(new List<string> 
-            { 
-                "mytype1", 
-                "mytype2" 
-            })));
-        });
+            "mytype1",
+            "mytype2"
+        })));
+    });
 
     //..
-    }
+}
 ```
 
 ### URL path to policy mapping
+
 By default, when computing the policy path, the middleware:
 * converts all slashes to dots
 * converts any character that is not alpha, digit, dot or underscore to underscore
@@ -96,21 +98,21 @@ public void ConfigureServices(IServiceCollection services)
    // Adds the Aserto Authorization service
    services.AddAsertoAuthorization(options =>
    {
-      Configuration.GetSection("Aserto").Bind(options));
+      Configuration.GetSection("Aserto").Bind(options);
       options.PolicyPathMapper = (policyRoot, httpRequest) =>
       {
           return "custom.policy.path";
       };
-   }
+   });
+
    //..  
 }
-
 ```
 
 ## Quickstart: Aserto Authorization on a ASP.NET Core MVC application
 
 **Prerequisites**
-* An connection to an [Identity Provider](/docs/getting-started/connect-idp)
+* A connection to an [Identity Provider](/docs/getting-started/connect-idp)
 * An Aserto [authorization policy](/docs/getting-started/create-policy)
 
 **Creating and setting up the project**
@@ -129,7 +131,6 @@ md src
 cd src
 
 dotnet new mvc -n QuickstartMVC
-
 ```
 
 This will create a .NET MVC application that exposes the following endpoints and http methods:
@@ -143,11 +144,10 @@ dotnet run --project dotnetmvc/src/QuickstartMVC/QuickstartMVC.csproj
 
 **Adding authentication**
 :::note
-This guide assumes that you already have an Auth0 account setup up and an Auth0 Regular Web Application created.
+This guide assumes that you already have an Auth0 account set up and an Auth0 Regular Web Application created.
 :::
 
-For authentication we will use the Cookie and OpenID Connect(OIDC) authentication middleware. For this you need to add `Microsoft.AspNetCore.Authentication.OpenIdConnect` package to your application. This can be done using NuGet by running the following command in your project directory:
-
+For authentication we will use the Cookie and OpenID Connect(OIDC) authentication middleware. For this you need to add the `Microsoft.AspNetCore.Authentication.OpenIdConnect` package to your application. This can be done using NuGet by running the following command in your project directory:
 ```cmd
 dotnetmvc\src\QuickstartMVC> dotnet add package Microsoft.AspNetCore.Authentication.OpenIdConnect
 ```
@@ -167,8 +167,7 @@ To enable authentication, you will need to update the `ConfigureServices` in you
     * `ClaimsIssuer` to "Auth0"
 5. Handle the logout redirection
 
-Below you've got a code sample that enable OIDC authentication:
-
+Below you've got a code sample that enables OIDC authentication:
 ``` csharp
 // Startup.cs
 
@@ -179,119 +178,117 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 //..
 
-        // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
-	    {
-	
-	        // Cookie configuration for HTTPS
-            services.Configure<CookiePolicyOptions>(options =>
+// This method gets called by the runtime. Use this method to add services to the container.
+public void ConfigureServices(IServiceCollection services)
+{
+    // Cookie configuration for HTTPS
+    services.Configure<CookiePolicyOptions>(options =>
+    {
+        options.MinimumSameSitePolicy = SameSiteMode.None;
+    });
+
+    // Add authentication services
+    services.AddAuthentication(options => {
+        options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+    })
+    .AddCookie()
+    .AddOpenIdConnect("Auth0", options => {
+        // Set the authority to your Auth0 domain
+        var domain = "YOUR_AUTH0_DOMAIN";
+        options.Authority = $"https://{domain}";
+
+        // Configure the Auth0 Client ID and Client Secret
+        options.ClientId = "YOUR_AUTH0_CLIENT_ID";
+        options.ClientSecret = "YOUR_AUTH0_CLIENT_SECRET";
+
+        // Set response type to code
+        options.ResponseType = OpenIdConnectResponseType.Code;
+
+        // Configure the scope
+        options.Scope.Clear();
+        options.Scope.Add("openid");
+        options.Scope.Add("profile");
+
+        // Set the callback path, so Auth0 will call back to http://localhost:5001/callback
+        // Also ensure that you have added the URL as an Allowed Callback URL in your Auth0 dashboard
+        options.CallbackPath = new PathString("/callback");
+
+        // Configure the Claims Issuer to be Auth0
+        options.ClaimsIssuer = "Auth0";
+
+        options.Events = new OpenIdConnectEvents
+        {
+            // handle the logout redirection
+            OnRedirectToIdentityProviderForSignOut = (context) =>
             {
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
-	    
-            // Add authentication services
-            services.AddAuthentication(options => {
-                options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-            })
-            .AddCookie()
-            .AddOpenIdConnect("Auth0", options => {
-                // Set the authority to your Auth0 domain
-                var domain = "YOUR_AUTH0_DOMAIN";
-                options.Authority = $"https://{domain}";
+                var logoutUri = $"https://{domain}/v2/logout?client_id={options.ClientId}";
 
-                // Configure the Auth0 Client ID and Client Secret
-                options.ClientId = "YOUR_AUTH0_CLIENT_ID";
-                options.ClientSecret = "YOUR_AUTH0_CLIENT_SECRET";
-
-                // Set response type to code
-                options.ResponseType = OpenIdConnectResponseType.Code;
-
-                // Configure the scope
-                options.Scope.Clear();
-                options.Scope.Add("openid");
-                options.Scope.Add("profile");
-
-                // Set the callback path, so Auth0 will call back to http://localhost:5001/callback
-                // Also ensure that you have added the URL as an Allowed Callback URL in your Auth0 dashboard
-                options.CallbackPath = new PathString("/callback");
-
-                // Configure the Claims Issuer to be Auth0
-                options.ClaimsIssuer = "Auth0";
-
-                options.Events = new OpenIdConnectEvents
+                var postLogoutUri = context.Properties.RedirectUri;
+                if (!string.IsNullOrEmpty(postLogoutUri))
                 {
-                    // handle the logout redirection
-                    OnRedirectToIdentityProviderForSignOut = (context) =>
+                    if (postLogoutUri.StartsWith("/"))
                     {
-                        var logoutUri = $"https://{domain}/v2/logout?client_id={options.ClientId}";
-
-                        var postLogoutUri = context.Properties.RedirectUri;
-                        if (!string.IsNullOrEmpty(postLogoutUri))
-                        {
-                            if (postLogoutUri.StartsWith("/"))
-                            {
-                                // transform to absolute
-                                var request = context.Request;
-                                postLogoutUri = request.Scheme + "://" + request.Host + request.PathBase + postLogoutUri;
-                            }
-                            logoutUri += $"&returnTo={ Uri.EscapeDataString(postLogoutUri)}";
-                        }
-
-                        context.Response.Redirect(logoutUri);
-                        context.HandleResponse();
-
-                        return Task.CompletedTask;
+                        // transform to absolute
+                        var request = context.Request;
+                        postLogoutUri = request.Scheme + "://" + request.Host + request.PathBase + postLogoutUri;
                     }
-                };
-            });
+                    logoutUri += $"&returnTo={ Uri.EscapeDataString(postLogoutUri)}";
+                }
 
-            services.AddControllersWithViews();
-        }
+                context.Response.Redirect(logoutUri);
+                context.HandleResponse();
+
+                return Task.CompletedTask;
+            }
+        };
+    });
+
+    services.AddControllersWithViews();
+}
 
 //..
-
 ```
 
-To add the authentication middleware to the middleware pipeline add a call to the `UseAuthentication` method in your Startup's `Configure` method:
-
-``` csharp
+To add the authentication middleware to the middleware pipeline, add a call to the `UseAuthentication` method in your Startup's `Configure` method:
+```csharp
 // Startup.cs
 
 //..
 
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            if (env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                app.UseExceptionHandler("/Home/Error");
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-                app.UseHsts();
-            }
-            app.UseHttpsRedirection();
-            app.UseStaticFiles();
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+    if (env.IsDevelopment())
+    {
+        app.UseDeveloperExceptionPage();
+    }
+    else
+    {
+        app.UseExceptionHandler("/Home/Error");
+        // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+        app.UseHsts();
+    }
+    app.UseHttpsRedirection();
+    app.UseStaticFiles();
 
-            app.UseRouting();
+    app.UseRouting();
 
-            // Adds the Authentication middleware to the middleware pipeline,
-            app.UseAuthentication();
+    // Adds the Authentication middleware to the middleware pipeline
+    app.UseAuthentication();
 
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllerRoute(
-                    name: "default",
-                    pattern: "{controller=Home}/{action=Index}/{id?}");
-            });
-        }
+    app.UseEndpoints(endpoints =>
+    {
+        endpoints.MapControllerRoute(
+            name: "default",
+            pattern: "{controller=Home}/{action=Index}/{id?}");
+    });
+}
+
 //..
 ```
 
-To handle authentication requests, we're going to add a new controller that can mange login and logout requests. This new controller is going to be named *AccountController* and needs to be added under the *Controller* folder:
+To handle authentication requests, we're going to add a new controller that can manage login and logout requests. This new controller is going to be named *AccountController* and needs to be added under the *Controller* folder:
 ```csharp
 // Controllers/AccountController.cs
 
@@ -356,11 +353,10 @@ Next we're going to add the login and logout buttons to the shared layout. To do
 </body>
 
 @* ... Code omitted for brevity ... *@
-
 ```
 
 :::note
-The callback url(https://localhost:5001/callback) configured in the `ConfigureServices` method of Startup.cs needs to be set as an *Allowed Callback URL* in Auth0. Similarly the logout url(https://localhost:5001/) needs to be set in the *Allowed Logout URLs* list.
+The callback url(https://localhost:5001/callback) configured in the `ConfigureServices` method of `Startup.cs` needs to be set as an *Allowed Callback URL* in Auth0. Similarly, the logout url(https://localhost:5001/) needs to be set in the *Allowed Logout URLs* list.
 :::
 
 **Creating policy for QuickstartMVC**
@@ -375,29 +371,27 @@ For the `QuickstartMVC` application created earlier, the policy folder structure
     ├── .manifest
     └── quickstartmvc
         ├── account
-        │   ├── login
-        │   │   └── get.rego
-        │   └── logout
-        │       └── get.rego
+        │   ├── login
+        │   │   └── get.rego
+        │   └── logout
+        │       └── get.rego
         ├── get.rego
         └── home
             ├── privacy
-            │   └── get.rego
+            │   └── get.rego
             └── profile
                 └── get.rego
 ```
 
 Where the `./src/.manifest` file contains our policy roots:
-
-``` json
+```json
 {
     "roots": ["quickstartmvc"]
 }
 ```
 
-the `./src/quickstartmvc/profile/get.rego` policy file contains rules for the `GET` http method on `/profile` URL path:
-
-``` rego
+And the `./src/quickstartmvc/profile/get.rego` policy file contains rules for the `GET` http method on `/profile` URL path:
+```rego
 package quickstartmvc.GET.home.profile
 
 default allowed = false
@@ -411,8 +405,8 @@ allowed {
 
 This policy allows access to `/profile` on `GET` only to users that have their identities verified.
 
-On the rest of the endpoints we're going to allow anonymous access, so the rest of the **.rego* files will contain:
-``` rego
+On the remaining endpoints we're going to allow anonymous access, so the rest of the **.rego* files will contain:
+```rego
 allowed = true
 ```
 
@@ -421,25 +415,23 @@ If you've created the policy from the default template, you need to create a tag
 :::
 
 **Adding Aserto authorization**
-To enable Aserto authorization you need to add a dependency to the Aserto dotnet middleware:
-
-``` cmd
+To enable Aserto authorization, you need to add a dependency to the Aserto dotnet middleware:
+```cmd
 $dotnetmvc/src/QuickstartMVC$ dotnet add package Aserto.AspNetCore.Middleware
 ```
 
-Configure the Authorizer API Key, Tenant ID, Policy root and Policy ID in the `appsettings.json`
-
-``` json
+Configure the Authorizer API Key, Tenant ID, Policy root and Policy ID in the `appsettings.json`:
+```json
 "Aserto": {
     "AuthorizerApiKey": "YOUR_AUTHORIZER_API_KEY",
-    "TenantID": "YOUT_ASERTO_TENANTID",
+    "TenantID": "YOUR_ASERTO_TENANT_ID",
     "PolicyID": "YOUR_ASERTO_POLICY_ID",
     "PolicyRoot": "quickstartmvc"
 }
 ```
 
-Configure the Aserto Authorization Service and add an authorization policy in the ConfigureServices method of `Startup.cs`
-``` csharp
+Configure the Aserto Authorization Service and add an authorization policy in the ConfigureServices method of `Startup.cs`:
+```csharp
 // Startup.cs
 
 //..
@@ -448,51 +440,54 @@ using Aserto.AspNetCore.Middleware.Policies;
 using Aserto.AspNetCore.Middleware.Extensions;
 //..
 
-        public void ConfigureServices(IServiceCollection services)
-        {
-            //.. Code omitted for brevity
+public void ConfigureServices(IServiceCollection services)
+{
+    //.. Code omitted for brevity
 
-            // Adds the Aserto Authorization service
-            services.AddAsertoAuthorization(options => Configuration.GetSection("Aserto").Bind(options));
-            
-            // Adds the Aserto policy and configures it as the default Authorization policy
-            services.AddAuthorization(options =>
-            {
-                // User is authenticated via a cookie.
-                var policy = new AuthorizationPolicyBuilder(CookieAuthenticationDefaults.AuthenticationScheme);
-                policy.AddRequirements(new AsertoDecisionRequirement());
-                options.DefaultPolicy = policy.Build();
-            });
+    // Adds the Aserto Authorization service
+    services.AddAsertoAuthorization(options => Configuration.GetSection("Aserto").Bind(options));
 
-            services.AddControllersWithViews();
-        }
+    // Adds the Aserto policy and configures it as the default Authorization policy
+    services.AddAuthorization(options =>
+    {
+        // User is authenticated via a cookie
+        var policy = new AuthorizationPolicyBuilder(CookieAuthenticationDefaults.AuthenticationScheme);
+        policy.AddRequirements(new AsertoDecisionRequirement());
+        options.DefaultPolicy = policy.Build();
+    });
+
+    services.AddControllersWithViews();
+}
+
 //..
 ```
 
-Add the Authorization middleware to the middleware pipeline by adding a call to the `UseAuthorization` method in your Startup's `Configure` method
-``` csharp
+Add the Authorization middleware to the middleware pipeline by adding a call to the `UseAuthorization` method in your Startup's `Configure` method:
+```csharp
 // Startup.cs
 
 //..
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-        {
-            //.. Code omitted for brevity
 
-            app.UseAuthentication();
-            app.UseAuthorization();
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+    //.. Code omitted for brevity
 
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllerRoute(
-                    name: "default",
-                    pattern: "{controller=Home}/{action=Index}/{id?}");
-            });
-        }
+    app.UseAuthentication();
+    app.UseAuthorization();
+
+    app.UseEndpoints(endpoints =>
+    {
+        endpoints.MapControllerRoute(
+            name: "default",
+            pattern: "{controller=Home}/{action=Index}/{id?}");
+    });
+}
+
 //..
 ```
 
 Next you need to create the Profile view that will display the claims of a logged in user. To do this, add a new file `Profile.cshtml` under the *Views/Home/* folder:
-``` cshtml
+```cshtml
 @* Views/Home/Profile.cshtml *@
 
 @using Microsoft.AspNetCore.Authentication
@@ -532,10 +527,9 @@ else
 {
     <h2>User not authenticated.</h2>
 }
-
 ```
-Add a new navigation bar that will call the view in *Views/Shared/_Layout.cshtml*:
 
+Add a new navigation bar that will call the view in *Views/Shared/_Layout.cshtml*:
 ```cshtml
 @* Views/Shared/_Layout.cshtml *@
 
@@ -567,7 +561,7 @@ Add a new navigation bar that will call the view in *Views/Shared/_Layout.cshtml
 ```
 
 And finally, add the `Profile` action in the *HomeController.cs*:
-``` csharp
+```csharp
 // Controllers/HomeController.cs
 
 //..


### PR DESCRIPTION
Funnily enough, this commit started from tiny nits such as `an` to `a` and various typos, but by the time I reached the end of the file I realized that I might've went a little overboard (especially with code examples indentation which are handled in a very special way in diff by git).

I hope these suggestions will be welcomed 😄.

🗒️  Notes:
* didn't get the chance to test this, however lines 101 and 106 have actual changes; it looked like syntax error to me but I might be wrong
* other code examples should have only unnecessary indentation removed (I would keep the original indentation but only with context: mentioning the classes/methods they're supposed to go into instead of just the filename)
* lines 374-377 contained NBSP unicode characters