### PR TITLE
read:email => user:email

### DIFF
--- a/docs/aserto-console/connections.mdx
+++ b/docs/aserto-console/connections.mdx
@@ -61,7 +61,7 @@ OAuth2 consent flow, your source code provider should show as connected.
 
 To connect to GitHub using a Personal Access Token (PAT), you need to create a PAT in the 
 [GitHub UI](https://github.com/settings/tokens) by clicking the "Generate new token" button. 
-Ensure that the selected scopes include at least `public_repo`, `read:org`, `read:user`, and `read:email` 
+Ensure that the selected scopes include at least `public_repo`, `read:org`, `read:user`, and `user:email` 
 so that the Aserto Console has access to the required profile and repository information.
 
 ![github pat](/github-pat.png)


### PR DESCRIPTION
The scope name for reading email in GitHub is `user:email`, not `read:email`.

WARNING: this link will take you to the GitHub Create PAT flow. [New Token](https://github.com/settings/tokens/new)