### PR TITLE
added okta as supported IDP

### DIFF
--- a/docs/command-line-interface/connections.mdx
+++ b/docs/command-line-interface/connections.mdx
@@ -18,7 +18,7 @@ A system connection stores the connection between the tenant and other Aserto se
 
 A user connection is one that the user has established between Aserto and one of their services. There are two types of user connections currently supported:
 
-- IDP (identity provider): this is a read-only connection between Aserto and an Identity Provider. Currently, only Auth0 is supported.
+- IDP (identity provider): this is a read-only connection between Aserto and an Identity Provider. Currently, Auth0 and Okta are supported.
 - SCC (source code control): this is a connection between Aserto and a source code control system. Currently, only GitHub is supported.
 
 To display detailed information about a particular connection, type

--- a/docs/overview/connections.mdx
+++ b/docs/overview/connections.mdx
@@ -16,7 +16,7 @@ the hosted authorizer.
 
 A user connection is one that the user has established between Aserto and one of their services. There 
 are two types of user connections currently supported: 
-* **IDP** (identity provider): this is a read-only connection between Aserto and an Identity Provider. Currently, only Auth0 is supported.
+* **IDP** (identity provider): this is a read-only connection between Aserto and an Identity Provider. Currently, Auth0 and Okta are supported.
 * **SCC** (source code control): this is a connection between Aserto and a source code control system. Currently, only GitHub is supported.
 
 ## Providers

--- a/docs/software-development-kits/python/identity-providers.mdx
+++ b/docs/software-development-kits/python/identity-providers.mdx
@@ -27,7 +27,7 @@ poetry add aserto-idp
 ## Usage
 
 :::note
-Currently Aserto supports Auth0 as an identity provider. More are on the way!
+Currently the Python SDK supports Auth0 as an identity provider. More are on the way!
 :::
 
 ### Creating an Auth0 `Identity`


### PR DESCRIPTION
In a few places, we still noted that only Auth0 is supported as an IDP. Made some changes to fix this.
