### PR TITLE
updated title and description meta tags for pages that had duplicates

### DIFF
--- a/docs/aserto-console/introduction.mdx
+++ b/docs/aserto-console/introduction.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Introduction
+title: Console Introduction
+description: Using the Aserto Console
 ---
 
 # Introduction

--- a/docs/authorizer-guide/overview.mdx
+++ b/docs/authorizer-guide/overview.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Overview
+title: Authorizer Guide
+description: How to use the Aserto Authorizer
 ---
 
 # Overview

--- a/docs/decision-logs-guide/api/overview.mdx
+++ b/docs/decision-logs-guide/api/overview.mdx
@@ -1,5 +1,8 @@
 ---
 sidebar_label: Overview
+title: Decision Logs APIs
+description: How to use the Aserto Decision Logs APIs
+
 ---
 
 # Overview

--- a/docs/decision-logs-guide/overview.mdx
+++ b/docs/decision-logs-guide/overview.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Overview
+title: Decision Logs Overview
+description: How to use Aserto decision logs
 ---
 
 # Overview

--- a/docs/getting-started-acmecorp/bring-your-own-idp/bring-your-own-idp.mdx
+++ b/docs/getting-started-acmecorp/bring-your-own-idp/bring-your-own-idp.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Overview
+title: Bring Your Own IDP (Auth0)
+description: Using Auth0 as your IDP
 ---
 
 # Bring Your Own Identity Provider (Auth0)

--- a/docs/getting-started-acmecorp/quickstart.mdx
+++ b/docs/getting-started-acmecorp/quickstart.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Overview
+title: PeopleFinder Quickstart
+description: Quickstart for the Peoplefinder sample application
 ---
 
 # PeopleFinder Quickstart

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: PeopleFinder Quickstart
+title: PeopleFinder Quickstart
+description: Quickstart for the Peoplefinder sample application
 ---
 
 # PeopleFinder Quickstart

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Welcome to Aserto!
+title: Home
+description: Home page for Aserto documentation
 id: index
 slug: /
 ---

--- a/docs/overview/introduction.mdx
+++ b/docs/overview/introduction.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Introduction
+title: Overview - Introduction
+description: Introduction to the Aserto solution
 ---
 
 # Introduction

--- a/docs/quickstarts/react/overview.mdx
+++ b/docs/quickstarts/react/overview.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Overview
+title: React and Express.js Quickstart
+description: Quickstart for React and Express
 ---
 
 # React.js and Node.js (Express.js) Quickstart

--- a/docs/software-development-kits/overview.mdx
+++ b/docs/software-development-kits/overview.mdx
@@ -1,5 +1,7 @@
 ---
 sidebar_label: Overview
+title: Aserto SDKs
+description: Overview of the Aserto language SDKs
 ---
 
 import SdkPage from '../../src/components/SdkPage'


### PR DESCRIPTION
Many sub-pages have a sidebar_label of 'Overview' This set the title meta tag to a duplicate of other pages.

This PR gives each of these a unique title, and also adds hand-crafted description meta tags where appropriate.
