### PR TITLE
remove playground from navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,12 +89,12 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
               label: "Product",
               target: "_self",
             },
-            {
-              to: "https://www.aserto.com/playground",
-              position: "left",
-              label: "Playground",
-              target: "_self",
-            },
+            // {
+            //   to: "https://www.aserto.com/playground",
+            //   position: "left",
+            //   label: "Playground",
+            //   target: "_self",
+            // },
             {
               to: "https://www.aserto.com/blog",
               label: "Blog",


### PR DESCRIPTION
at `/docs` you can see that the playground nav item has been removed

![image](https://user-images.githubusercontent.com/11022003/159570727-7934ea76-9a58-4128-9a5a-c87193fbd659.png)
