### PR TITLE
Update installation.mdx

### DIFF
--- a/docs/command-line-interface/aserto-idp-cli/installation.mdx
+++ b/docs/command-line-interface/aserto-idp-cli/installation.mdx
@@ -18,5 +18,5 @@ sidebar_label: Installation
 
   ```shell
   # NOTE: The dev version will be in effect!
-  go get -u github.com/aserto-dev/aserto-idp
+  go install github.com/aserto-dev/aserto-idp@latest
   ```


### PR DESCRIPTION
        go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.