### PR TITLE
turn off trailing slash in docusaurus.config

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -8,7 +8,7 @@ description: Aserto API Reference
 
 ## Conceptual overview
 
-If you'd like a conceptual overview of Aserto before diving into the APIs, start with the [introduction](overview/introduction).
+If you'd like a conceptual overview of Aserto before diving into the APIs, start with the [introduction](/docs/overview/introduction).
 
 ## API documentation
 
@@ -29,4 +29,4 @@ so that you can directly execute API calls from the dashboard.
 
 ## Authorizer Guide
 
-For an overview of the Aserto Authorizer APIs, start with the [Authorizer Guide](authorizer-guide/overview).
+For an overview of the Aserto Authorizer APIs, start with the [Authorizer Guide](/docs/authorizer-guide/overview).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -19,13 +19,13 @@ The [API Reference](https://aserto.readme.io/reference) contains (executable) do
 
 The Aserto documentation is organized as follows:
 
-- [Overview](overview/introduction): a conceptual overview of Aserto's different moving parts
-- [Getting Started](getting-started-acmecorp/quickstart): a step-by-step walkthrough to get a demo app up-and running using Aserto
-- [Aserto Console](aserto-console/introduction): an overview of the workflows supported by the Aserto Console
-- [Authorizer Guide](authorizer-guide/overview): a guide for interacting with the Aserto Authorizer
-- [Quickstarts](quickstarts/react/overview): a guide for creating a React application and an Express.js service that utilize Aserto for authorization
-- [SDKs](software-development-kits/overview): the Aserto language-specific SDKs
-- [Command-Line Interfaces](command-line-interface/introduction): an overview of the Aserto and Policy CLIs
-- [Decisions Logs Guide](decision-logs-guide/overview): a guide for using Aserto decision logs
-- [Edge Authorizers](edge-authorizers/overview): a guide for setting up edge authorizers
-- [Troubleshooting](troubleshooting/overview): a list of common problems and how to resolve them
+- [Overview](/docs/overview/introduction): a conceptual overview of Aserto's different moving parts
+- [Getting Started](/docs/getting-started-acmecorp/quickstart): a step-by-step walkthrough to get a demo app up-and running using Aserto
+- [Aserto Console](/docs/aserto-console/introduction): an overview of the workflows supported by the Aserto Console
+- [Authorizer Guide](/docs/authorizer-guide/overview): a guide for interacting with the Aserto Authorizer
+- [Quickstarts](/docs/quickstarts/react/overview): a guide for creating a React application and an Express.js service that utilize Aserto for authorization
+- [SDKs](/docs/software-development-kits/overview): the Aserto language-specific SDKs
+- [Command-Line Interfaces](/docs/command-line-interface/introduction): an overview of the Aserto and Policy CLIs
+- [Decisions Logs Guide](/docs/decision-logs-guide/overview): a guide for using Aserto decision logs
+- [Edge Authorizers](/docs/edge-authorizers/overview): a guide for setting up edge authorizers
+- [Troubleshooting](/docs/troubleshooting/overview): a list of common problems and how to resolve them

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,6 +14,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
     favicon: "img/favicon.ico",
     organizationName: "aserto-dev",
     projectName: "aserto-docs",
+    trailingSlash: false,
 
     plugins: [
       ['docusaurus2-dotenv',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -242,7 +242,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
           accountId: process.env.REACT_APP_HUBSPOT_ACCOUNT_ID ?? 21300286
         },
         gtag: {
-          trackingID: process.env.REACT_APP_GOOGLE_ANALYTICS_MEASUREMENT_ID,
+          trackingID: process.env.REACT_APP_GOOGLE_ANALYTICS_MEASUREMENT_ID ?? '_',
           anonymizeIP: true,
         }
       }),

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
   from = "/"
   to = "/docs"
-  status = 200
+  status = 301


### PR DESCRIPTION
Purpose: get Docusaurus to emit no trailing slashes for URLs, and netlify to automatically redirect `.../abc/` to `.../abc`
