### PR TITLE
fixed scopes required for GH PAT

### DIFF
--- a/docs/aserto-console/connections/setup-github.mdx
+++ b/docs/aserto-console/connections/setup-github.mdx
@@ -18,7 +18,7 @@ To connect to GitHub using a Personal Access Token (PAT), you need to create a P
 [GitHub UI](https://github.com/settings/tokens) by clicking the "Generate new token" button.
 
 :::caution Note
-Ensure that the selected scopes include at least `repo`, `read:org`, and `admin:repo_hook`
+Ensure that the selected scopes include at least `repo` and `read:org`
 so that the Aserto Console has access to the required repository information.
 :::
 

--- a/docs/aserto-console/connections/setup-github.mdx
+++ b/docs/aserto-console/connections/setup-github.mdx
@@ -16,8 +16,11 @@ OAuth2 consent flow, your source code provider should show as connected.
 
 To connect to GitHub using a Personal Access Token (PAT), you need to create a PAT in the
 [GitHub UI](https://github.com/settings/tokens) by clicking the "Generate new token" button.
-Ensure that the selected scopes include at least `public_repo`, `read:org`, `read:user`, and `user:email`
-so that the Aserto Console has access to the required profile and repository information.
+
+:::caution Note
+Ensure that the selected scopes include at least `repo`, `read:org`, and `admin:repo_hook`
+so that the Aserto Console has access to the required repository information.
+:::
 
 ![github pat](/github-pat.png)
 


### PR DESCRIPTION
This [doc](https://docs.aserto.com/docs/aserto-console/connections/setup-github) lists the wrong scopes required for a GH PAT. 

Instead of `public_repo, read:org, read:user, user:email` Aserto needs `repo, read:org, admin:repo_hook`.

