### PR TITLE
fix algolia search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,6 +76,7 @@ const darkCodeTheme = require("prism-react-renderer/themes/dracula");
           apiKey: process.env.REACT_APP_ALGOLIA_API_KEY || '_',
           indexName: process.env.REACT_APP_ALGOLIA_INDEX_NAME || '_',
           appId: process.env.REACT_APP_ALGOLIA_APP_ID || '_',
+          contextualSearch: false,
         },
         image: 'img/aserto-logo.png',
         navbar: {


### PR DESCRIPTION
Algolia search broke with the upgrade to docusaurus 2.0.1. This PR removes the contextual search parameters from the POST request which appears to fix the search.
