### PR TITLE
changed docs to refer to properties instead of attributes

### DIFF
--- a/docs/authorizer-guide/display-state-map.mdx
+++ b/docs/authorizer-guide/display-state-map.mdx
@@ -12,7 +12,7 @@ the front-end typically wants to avoid displaying UI elements that allow users t
 
 Aserto addresses this problem by defining the **display state map** pattern. An authorization policy
 defines [decisions](/docs/overview/policy#decision) called `visible` and `enabled`, which take on `true` / `false`
-values when evaluated against the roles and attributes of the logged-in user. We refer to the following
+values when evaluated against the roles and properties of the logged-in user. We refer to the following
 type of JSON map as a **display state**:
 
 ```json
@@ -20,7 +20,7 @@ type of JSON map as a **display state**:
 ```
 
 Aserto's [`decisiontree`](/docs/authorizer-guide/decisiontree) API makes it possible to compute these _display states_
-for **every route or permission in your application** based on the roles and attributes of the logged-in
+for **every route or permission in your application** based on the roles and properties of the logged-in
 user. We call this map of maps a **display state map** and it looks like this:
 
 ```json

--- a/docs/authorizer-guide/identity-context.mdx
+++ b/docs/authorizer-guide/identity-context.mdx
@@ -51,7 +51,7 @@ default allowed = false
 
 # only allow salespeople
 allowed {
-  input.user.attributes.properties.department == "Sales"
+  input.user.properties.department == "Sales"
 }
 ```
 
@@ -87,7 +87,7 @@ token = {"payload": payload} {
 
 # only allow sales managers
 allowed {
-  input.user.attributes.properties.department == "Sales"
+  input.user.properties.department == "Sales"
   token.payload.manager
 }
 ```

--- a/docs/authorizer-guide/policy.mdx
+++ b/docs/authorizer-guide/policy.mdx
@@ -79,7 +79,7 @@ the `/policy/policies/{id}` call.
   "module": {
     "id": "YXNlcnRvMS9wZW9wbGVmaW5kZXIvdXNlcnMvcG9zdC5yZWdv",
     "name": "peoplefinder.POST.api.users",
-    "content": "package peoplefinder.POST.api.users\n\ndefault allowed = false\n\ndefault visible = false\n\ndefault enabled = false\n\nallowed {\n\tu = input.user\n\tu.attributes.properties.department == \"Operations\"\n\tu.attributes.properties.title == \"IT Manager\"\n}\n\nvisible {\n\tallowed\n}\n\nenabled {\n\tallowed\n}\n",
+    "content": "package peoplefinder.POST.api.users\n\ndefault allowed = false\n\ndefault visible = false\n\ndefault enabled = false\n\nallowed {\n\tu = input.user\n\tu.properties.department == \"Operations\"\n\tu.properties.title == \"IT Manager\"\n}\n\nvisible {\n\tallowed\n}\n\nenabled {\n\tallowed\n}\n",
     "rules": ["allowed", "visible", "enabled", "allowed", "visible", "enabled"]
   }
 }

--- a/docs/getting-started/bring-your-own-idp/bring-your-own-idp.mdx
+++ b/docs/getting-started/bring-your-own-idp/bring-your-own-idp.mdx
@@ -8,7 +8,7 @@ description: Using Auth0 as your IDP
 
 ## Overview
 
-Aserto can connect to one or more identity providers as the source of user attributes and roles. So far, we were using the Acmecorp demo identity provider. Next, we’re going to review how to connect Auth0 as an identity provider. Then, we’ll seed your IDP with a set of users different from the ones which exist in the Acmecorp demo IDP.
+Aserto can connect to one or more identity providers as the source of user properties and roles. So far, we were using the Acmecorp demo identity provider. Next, we’re going to review how to connect Auth0 as an identity provider. Then, we’ll seed your IDP with a set of users different from the ones which exist in the Acmecorp demo IDP.
 
 ## Remove the Acmecorp Users
 

--- a/docs/getting-started/bring-your-own-idp/extend-user-attributes.mdx
+++ b/docs/getting-started/bring-your-own-idp/extend-user-attributes.mdx
@@ -1,21 +1,21 @@
 ---
-sidebar_label: Extend user attributes
-title: Extend user attributes
-description: Extending user attributes for PeopleFinder users
+sidebar_label: Extend user properties
+title: Extend user properties
+description: Extending user properties for PeopleFinder users
 ---
 
-# Add extended attributes for PeopleFinder users
+# Add extended properties for PeopleFinder users
 
-PeopleFinder expects to operate over users with extended attributes like department, title, manager.
+PeopleFinder expects to operate over users with extended properties like department, title, manager.
 
-These extended attributes can come from the identity provider, or can be stored as user extensions
+These extended properties can come from the identity provider, or can be stored as user extensions
 in the Aserto directory. This second option is more flexible, since it doesn't require an application
 to have write access to a customer's identity provider in order to store properties, roles, or permissions.
 
 The PeopleFinder sample demonstrates this use case. It utilizes three properties that aren't stored
 in the identity provider: **department**, **title**, and **manager**.
 
-We're going to use the Aserto CLI to add these extended attributes to each of the users that Aserto
+We're going to use the Aserto CLI to add these extended properties to each of the users that Aserto
 imported from the identity provider (Auth0) in the last step.
 
 ## Install the Aserto CLI
@@ -80,13 +80,13 @@ we loaded into Auth0 in the [Set up test users](/docs/getting-started/bring-your
 curl https://raw.githubusercontent.com/aserto-dev/aserto-cli/main/assets/peoplefinder.json >peoplefinder.json
 ```
 
-Use the Aserto CLI to upload extended attributes for every user we created in Auth0:
+Use the Aserto CLI to upload extended properties for every user we created in Auth0:
 
 ```bash
 aserto directory load-user-ext --provider=json --file=peoplefinder.json
 ```
 
-Verify that the users now have extended attributes:
+Verify that the users now have extended properties:
 
 ```bash
 aserto directory get-user-props karinl@acmecorp.com

--- a/docs/getting-started/bring-your-own-idp/set-up-auth0.mdx
+++ b/docs/getting-started/bring-your-own-idp/set-up-auth0.mdx
@@ -94,5 +94,5 @@ Complete the form using the domain, client ID and client secret associated with 
 
 ## Next steps
 
-Next, we'll extend the users we've just imported from Auth0 with custom attributes that
+Next, we'll extend the users we've just imported from Auth0 with custom properties that
 the PeopleFinder application expects to have on the user records.

--- a/docs/getting-started/explore-abac-policies/creating-an-abac-policy.mdx
+++ b/docs/getting-started/explore-abac-policies/creating-an-abac-policy.mdx
@@ -74,9 +74,9 @@ Open the policy instance once it is created, and open the `peoplefinder.POST.api
 
 ![console-policy-peoplefinder-post](/getting-started/console-policy-peoplefinder-post.png)
 
-As you can see, this policy is slightly different from the RBAC policy we created before: instead of referencing the `data` object (which is based on the definitions in the `data.json` file) and the roles defined there, it uses the user's _attributes_ to determine whether they are equal to a specific value.
+As you can see, this policy is slightly different from the RBAC policy we created before: instead of referencing the `data` object (which is based on the definitions in the `data.json` file) and the roles defined there, it uses the user's _properties_ to determine whether they are equal to a specific value.
 
-In this module, we check whether the user's `department` attribute is equal to `Operations`. If the check yields a `true` value, the user will be `allowed` to perform the `POST` operation on the `/api/users/:id` resource - which means they'll be able to update the `title` and `department` attributes of another user.
+In this module, we check whether the user's `department` property is equal to `Operations`. If the check yields a `true` value, the user will be `allowed` to perform the `POST` operation on the `/api/users/:id` resource - which means they'll be able to update the `title` and `department` property of another user.
 
 This policy will result in a dynamic behavior of the authorization model: any user assigned to the `Operations` department _at runtime_ will now have the permission to make updates to other users as well.
 

--- a/docs/getting-started/explore-abac-policies/overview.mdx
+++ b/docs/getting-started/explore-abac-policies/overview.mdx
@@ -10,10 +10,10 @@ description: Attribute Based Access Control - an Overview
 
 In the PeopleFinder Quickstart, we used RBAC (Role Based Access Control) to control access to the PeopleFinder application's endpoints. In this section, we'll explore the concept of Attribute Based Access Control and see how it can provide us with a more granular and dynamic authorization model.
 
-Unlike RBAC, which categorizes users into a distinct set of roles, ABAC allows us to use any number of attributes a user may have to determine if they have access to a particular resource. While roles give us a sense of _what the user's job_ is in an organization, attributes give us a sense of _who the user is_ and what properties are particular to them.
+Unlike RBAC, which categorizes users into a distinct set of roles, ABAC allows us to use any number of attributes or properties a user may have to determine if they have access to a particular resource. While roles give us a sense of _what the user's job_ is in an organization, attributes give us a sense of _who the user is_ and what properties are particular to them.
 
 For example, some of these attributes could be a user's location, their IP address, the type of device they're using, their current department, the project they're working on, etc. Defining rules based on attributes that can change over time gives this authorization model a _dynamic_ quality: the authorization decision will depend on the user's attributes' value at runtime.
 
-With ABAC, we can define fine-grained rules that may include multiple user attributes. For example, we may want to allow a user to access a resource if they are a member of a specific department while working on a specific project and during a specific time period.
+With ABAC, we can define fine-grained rules that may include multiple user properties. For example, we may want to allow a user to access a resource if they are a member of a specific department while working on a specific project and during a specific time period.
 
 As we'll see in this example, the dynamic behavior we can achieve with ABAC could be used to support a wide variety of use cases that couldn't be satisfied using RBAC alone. That said, we have to use ABAC judiciously, since it can increase the complexity of our authorization model and make it more difficult to maintain.

--- a/docs/getting-started/explore-abac-policies/update-app-and-review.mdx
+++ b/docs/getting-started/explore-abac-policies/update-app-and-review.mdx
@@ -56,7 +56,7 @@ If we were using an RBAC model, we would have had to explicitly give Euan the ro
 
 ## Summary
 
-In this section we learned how powerful of an authorization model ABAC is, and how it can be used to create a dynamic authorization behavior - based on user attributes. We saw how it lets us define more granular authorization models that can take into account an arbitrary number of attributes. In some cases, using RBAC will not be enough to address all the complex scenarios present in the application. In those cases, we can rely on ABAC to provide us with a more granular and dynamic authorization model.
+In this section we learned how powerful of an authorization model ABAC is, and how it can be used to create a dynamic authorization behavior - based on user attributes. We saw how it lets us define more granular authorization models that can take into account an arbitrary number of properties. In some cases, using RBAC will not be enough to address all the complex scenarios present in the application. In those cases, we can rely on ABAC to provide us with a more granular and dynamic authorization model.
 
 ## Next steps
 

--- a/docs/getting-started/peoplefinder/explore-peoplefinder.mdx
+++ b/docs/getting-started/peoplefinder/explore-peoplefinder.mdx
@@ -10,7 +10,7 @@ Click on the Login button and sign in with `euang@acmecorp.com` - the password i
 
 ![login-screen](/getting-started/login-screen.png)
 
-The users loaded into your directory have attributes like manager and department, which the PeopleFinder application relies on, and are used in the authorization policies.
+The users loaded into your directory have properties like manager and department, which the PeopleFinder application relies on, and are used in the authorization policies.
 
 ![users-list](/getting-started/users-list.png)
 

--- a/docs/getting-started/peoplefinder/modify-the-policy.mdx
+++ b/docs/getting-started/peoplefinder/modify-the-policy.mdx
@@ -22,7 +22,7 @@ As mentioned before, the naming convention for packages is `policyroot.METHOD.ro
 - `METHOD` is `POST` (signifying an `HTTP POST` method)
 - `route` is `api.users.__id` (signifying the `/api/users/:id route`, with periods instead of slashes for a delimiter, following the Rego EBNF rules)
 
-This module controls access to the “Update” button at the bottom of a User card, and defines the policy that authorizes users to make changes to department and title attributes.
+This module controls access to the “Update” button at the bottom of a User card, and defines the policy that authorizes users to make changes to department and title properties.
 
 :::caution note
 Don't confuse the this with the `peoplefinder.POST.api.users` policy, which controls the ability to add new users.
@@ -94,7 +94,7 @@ The final state of the Rego file should look like the code listing below:
 package peoplefinder.POST.api.users.__id
 
 import input.policy.path
-import input.user.attributes
+import input.user.properties
 
 default allowed = false
 
@@ -104,7 +104,7 @@ default enabled = false
 
 allowed {
 	some index
-	data.roles[attributes.roles[index]].perms[path].allowed
+	data.roles[properties.roles[index]].perms[path].allowed
 }
 
 allowed {
@@ -113,12 +113,12 @@ allowed {
 
 visible {
 	some index
-	data.roles[attributes.roles[index]].perms[path].visible
+	data.roles[properties.roles[index]].perms[path].visible
 }
 
 enabled {
 	some index
-	data.roles[attributes.roles[index]].perms[path].enabled
+	data.roles[properties.roles[index]].perms[path].enabled
 }
 
 enabled {

--- a/docs/getting-started/peoplefinder/set-up-users.mdx
+++ b/docs/getting-started/peoplefinder/set-up-users.mdx
@@ -7,7 +7,7 @@ description: Set up demo users for PeopleFinder
 # Set up demo users for PeopleFinder
 
 Aserto needs to know about your users in order to make authorization decisions over
-various attributes of these users (including _roles_ and _properties_). In order to do this,you'll need to connect Aserto with an identity provider, so that Aserto can import and sync users and their attributes.
+various attributes of these users (including _roles_ and _properties_). In order to do this,you'll need to connect Aserto with an identity provider, so that Aserto can import and sync users and their properties.
 
 The PeopleFinder application operates over users with roles (such as `viewer`, `editor` and `admin`) as well as properties (such as `department`, `title` and `manager`). We've created a sample identity provider that contains a set of users with the requisite attributes. The users all work at a company called **Acmecorp**, and the identity provider is therefore called `acmecorp`.
 
@@ -41,7 +41,7 @@ Finally click “Add connection”:
 
 <img src="/getting-started/add-connection-button.png" width="170px" />
 
-When a new connection to an identity provider is added, Aserto automatically imports the users from that identity provider into the Aserto Directory. The users loaded into the directory have different roles and attributes that will help us understand how authorization works. To see them, click on the Directory tab:
+When a new connection to an identity provider is added, Aserto automatically imports the users from that identity provider into the Aserto Directory. The users loaded into the directory have different properties that will help us understand how authorization works. To see them, click on the Directory tab:
 
 <img src="/directory-tab.png" width="500px" />
 
@@ -58,25 +58,18 @@ Click on the user card and examine the JSON object (shortened here for brevity):
   "id": "cirkzmrhzgmzos03mzm1ltqwngqtywy2ni1jnzdjzjezyte1zjgsbwxvy2fs",
   "display_name": "Euan Garden",
   ...
-  "identities": {
-    ...
-  },
-  "attributes": {
-    "properties": {
-      "department": "Sales Engagement Management",
-      "manager": "2bfaa552-d9a5-41e9-a6c3-5be62b4433c8",
-      "phone": "+1-804-555-3383",
-      "title": "Salesperson"
-    },
+  "properties": {
+    "department": "Sales Engagement Management",
+    "manager": "2bfaa552-d9a5-41e9-a6c3-5be62b4433c8",
+    "phone": "+1-804-555-3383",
+    "title": "Salesperson",
     "roles": [
       "acmecorp",
       "sales-engagement-management",
       "user",
       "viewer"
-    ],
-    "permissions": []
+    ]
   },
-  "applications": {},
   "metadata": {
     "created_at": "2021-11-08T21:16:13.883383606Z",
     "updated_at": "2021-11-08T21:16:13.883383606Z",
@@ -93,25 +86,18 @@ As you can see here, Euan has the role of a `viewer` (among others), and he is a
   "id": "cirknjriodq3ni0zyzvmltrjywytywy2zi05ytbmmwm1mwqxowysbwxvy2fs",
   "display_name": "Kris Johnsen",
   ...
-  "identities": {
-    ...
-  },
-  "attributes": {
-    "properties": {
-      "department": "Operations",
-      "manager": "a528dc1d-0042-484d-81cb-dc58c95d8147",
-      "phone": "+1-206-555-9001",
-      "title": "IT Manager"
-    },
+  "properties": {
+    "department": "Operations",
+    "manager": "a528dc1d-0042-484d-81cb-dc58c95d8147",
+    "phone": "+1-206-555-9001",
+    "title": "IT Manager",
     "roles": [
       "acmecorp",
       "admin",
       "operations",
       "user"
-    ],
-    "permissions": []
+    ]
   },
-  "applications": {},
   "metadata": {
     "created_at": "2021-11-09T11:16:16.289969130Z",
     "updated_at": "2021-11-09T11:16:16.289969130Z",

--- a/docs/getting-started/peoplefinder/understanding-policies.mdx
+++ b/docs/getting-started/peoplefinder/understanding-policies.mdx
@@ -44,42 +44,16 @@ Aserto caches all user information in the Authorizer, so that we can use the ide
 {
   "id": "cirkzmrhzgmzos03mzm1ltqwngqtywy2ni1jnzdjzjezyte1zjgsbwxvy2fs",
   "enabled": true,
-  "display_name": "Euan Garden",
+  "displayName": "Euan Garden",
   "email": "euang@acmecorp.com",
   "picture": "https://github.com/aserto-demo/contoso-ad-sample/raw/main/UserImages/Euan%20Garden.jpg",
-  "identities": {
-    "+1-804-555-3383": {
-      "kind": "IDENTITY_KIND_PHONE",
-      "provider": "",
-      "verified": false
-    },
-    "CiRkZmRhZGMzOS03MzM1LTQwNGQtYWY2Ni1jNzdjZjEzYTE1ZjgSBWxvY2Fs": {
-      "kind": "IDENTITY_KIND_PID",
-      "provider": "local",
-      "verified": true
-    },
-    "euang": {
-      "kind": "IDENTITY_KIND_USERNAME",
-      "provider": "",
-      "verified": false
-    },
-    "euang@acmecorp.com": {
-      "kind": "IDENTITY_KIND_EMAIL",
-      "provider": "local",
-      "verified": true
-    }
-  },
-  "attributes": {
-    "properties": {
-      "department": "Sales Engagement Management",
-      "manager": "2bfaa552-d9a5-41e9-a6c3-5be62b4433c8",
-      "phone": "+1-804-555-3383",
-      "title": "Salesperson"
-    },
+  "properties": {
+    "department": "Sales Engagement Management",
+    "manager": "2bfaa552-d9a5-41e9-a6c3-5be62b4433c8",
+    "phone": "+1-804-555-3383",
+    "title": "Salesperson"
     "roles": ["acmecorp", "sales-engagement-management", "user", "viewer"],
-    "permissions": []
   },
-  "applications": {},
   "metadata": {
     "created_at": "2021-11-08T21:16:13.883383606Z",
     "updated_at": "2021-11-08T21:16:13.883383606Z",
@@ -117,10 +91,10 @@ The first line of the policy defines the name of the package using the Rego `pac
 
 ```
 import input.policy.path
-import input.user.attributes.roles as user_roles
+import input.user.properties.roles as user_roles
 ```
 
-Here we use the `import` directive to access the user object which is made available to the policy by Aserto. In this example, we alias `input.policy.path` object which will allow us to refer the policy’s path - `people.GET.api.users` - directly without specifying the full path. Similarly, we import `attributes.roles` in the user object as `user_roles` so that later on in the policy we can refer to it directly.
+Here we use the `import` directive to access the user object which is made available to the policy by Aserto. In this example, we alias `input.policy.path` object which will allow us to refer the policy’s path - `peoplefinder.GET.api.users` - directly without specifying the full path. Similarly, we import `input.user.properties.roles` in the user object as `user_roles` so that later on in the policy we can refer to it directly.
 
 ```
 default allowed = false
@@ -152,10 +126,8 @@ This expression will use the `some index` expression to iterate over all the rol
 
 ```json
 {
-  "attributes": {
-    "properties": {...},
+  "properties": {
     "roles": ["acmecorp", "sales-engagement-management", "user", "viewer"],
-    "permissions": []
   }
 }
 ```
@@ -172,15 +144,15 @@ For each one of those roles, the policy will access the `roles` object in the `d
 {
   "roles": {
     "viewer": {
-        "description": "PeopleFinder viewer",
-        "perms": {
-          "peoplefinder.GET.api.users": {
-              "allowed": true,
-              "visible": true,
-              "enabled": true
-          },
-         ...
-        }
+      "description": "PeopleFinder viewer",
+      "perms": {
+        "peoplefinder.GET.api.users": {
+            "allowed": true,
+            "visible": true,
+            "enabled": true
+        },
+        ...
+      }
     },
     "editor": {...},
     "admin": {...}
@@ -198,22 +170,22 @@ Unlike a `viewer`, an `admin` user trying to access `PUT api/users/:id` will be 
 
 ```json
 {
-    "roles": {
-        "viewer": {...},
-        "editor": {...},
-        "admin": {
-            "description": "PeopleFinder administrator",
-            "perms": {
-               ...
-                "peoplefinder.PUT.api.users.__id": {
-                    "allowed": true,
-                    "visible": true,
-                    "enabled": true
-                },
-               ...
-            }
-        }
+  "roles": {
+    "viewer": {...},
+    "editor": {...},
+    "admin": {
+      "description": "PeopleFinder administrator",
+      "perms": {
+        ...
+        "peoplefinder.PUT.api.users.__id": {
+          "allowed": true,
+          "visible": true,
+          "enabled": true
+        },
+        ...
+      }
     }
+  }
 }
 ```
 

--- a/docs/overview/connections.mdx
+++ b/docs/overview/connections.mdx
@@ -45,5 +45,5 @@ new repository based on an existing template repository.
 
 Connections are created using the Aserto [Console](/docs/aserto-console/connections/overview). Currently, a tenant
 member can connect a source code control system (e.g. GitHub) as the source of Policy repositories,
-and an identity provider (e.g. Auth0) as the source of users and user attributes that are managed
+and an identity provider (e.g. Auth0) as the source of users and user properties that are managed
 by the Aserto [directory](/docs/overview/directory).

--- a/docs/overview/directory.mdx
+++ b/docs/overview/directory.mdx
@@ -101,7 +101,7 @@ There is one Aserto Directory per tenant, and the directory contents are shared 
 ## Authorizer Directory (EDS)
 
 Each Authorizer instance has its own clone of the directory, known as the Edge Directory Service (EDS).
-Authorizers use the EDS for real-time access to anything stored in the directory, including user attributes,
+Authorizers use the EDS for real-time access to anything stored in the directory, including user properties,
 groups, roles/relationships, and any other objects. These can be accessed in policies to help make authorization decisions.
 
 Aserto transparently synchronizes changes from the source identity providers (e.g. Auth0) to the Aserto
@@ -120,7 +120,7 @@ The Authorizer will resolve the user identity in the Directory. It will then loa
 Each object has a JSON property bag that allows storing additional information for that object.
 
 For example, the Aserto Directory stores a read-only replica of the user data it receives (and merges) from various
-identity providers. Administrators and application developers can store custom attributes in the JSON property bag without
+identity providers. Administrators and application developers can store custom properties in the JSON property bag without
 worrying about conflicts with the identity provider.
 
 ## Built-ins

--- a/docs/overview/policy.mdx
+++ b/docs/overview/policy.mdx
@@ -42,7 +42,7 @@ package sample.GET.api.orders
 default allowed = false
 
 allowed {
-  input.user.attributes.department == "Sales"
+  input.user.properties.department == "Sales"
 }
 ```
 

--- a/docs/quickstarts/react/adding-users.mdx
+++ b/docs/quickstarts/react/adding-users.mdx
@@ -6,7 +6,7 @@ description: React and Express.js quickstart - How to add Users to the Aserto Di
 
 # Add Users to the Aserto Directory
 
-Since our application deals with user access, we're going to need users in our directory. Aserto lets us add identity providers and automatically syncs the users registered with those identity providers to the Aserto directory and authorizer. In this tutorial we’re going to use the Acmecorp Identity Provider, which simulates an identity provider with hundreds of users, each with their own set of roles and attributes.
+Since our application deals with user access, we're going to need users in our directory. Aserto lets us add identity providers and automatically syncs the users registered with those identity providers to the Aserto directory and authorizer. In this tutorial we’re going to use the Acmecorp Identity Provider, which simulates an identity provider with hundreds of users, each with their own set of properties.
 
 Log in to your Aserto account. To add the Acmecorp identity provider, go to the Connections tab, and click “Add connection”.
 
@@ -29,23 +29,17 @@ Click on the "Directory" tab. The users you’ll see have been imported from the
 
 You’ll see the following JSON object (shortened here for brevity):
 
-```
+```json
 {
   "id": "cirkzmrhzgmzos03mzm1ltqwngqtywy2ni1jnzdjzjezyte1zjgsbwxvy2fs",
-  "enabled": true,
-  "display_name": "Euan Garden",
+  "displayName": "Euan Garden",
   "email": "euang@acmecorp.com",
   ...
-  "identities": {
-    ...
-  },
-  "attributes": {
-    "properties": {
-      "department": "Sales Engagement Management",
-      "manager": "2bfaa552-d9a5-41e9-a6c3-5be62b4433c8",
-      "phone": "+1-804-555-3383",
-      "title": "Salesperson"
-    },
+  "properties": {
+    "department": "Sales Engagement Management",
+    "manager": "2bfaa552-d9a5-41e9-a6c3-5be62b4433c8",
+    "phone": "+1-804-555-3383",
+    "title": "Salesperson"
     "roles": [
       "acmecorp",
       "sales-engagement-management",

--- a/docs/quickstarts/react/conditional-ui-rendering.mdx
+++ b/docs/quickstarts/react/conditional-ui-rendering.mdx
@@ -21,7 +21,7 @@ First, we’ll update our policy to include clauses for `visible` and `enabled`.
 ```
 package asertodemo.GET.api.protected
 
-import input.user.attributes.roles as user_roles
+import input.user.properties.roles as user_roles
 
 default allowed = false
 

--- a/docs/quickstarts/react/create-a-policy.mdx
+++ b/docs/quickstarts/react/create-a-policy.mdx
@@ -98,7 +98,7 @@ default allowed = false
 
 allowed {
 	some index
-	input.user.attributes.roles[index] == "admin"
+	input.user.properties.roles[index] == "admin"
 }
 ```
 
@@ -106,7 +106,7 @@ By default, the `allowed` decision is going to be `false` - this follows the pri
 
 At runtime, the application will send the JWT associated with the logged in user. The Express.js service will relay the JWT along with the request path as the identity and resource contexts respectively to the authorizer.
 
-The `some index` and `...roles[index]` expressions indicate the authorizer will iterate over all the elements in the `roles` array under the `attributes` property in the user object. The authorizer will check if the iterated role is equal to the string `admin`. If it is, the `allowed` decision will evaluate to `true`.
+The `some index` and `...roles[index]` expressions indicate the authorizer will iterate over all the elements in the `roles` array under the `properties` in the user object. The authorizer will check if the iterated role is equal to the string `admin`. If it is, the `allowed` decision will evaluate to `true`.
 
 ## Updating the Policy Repository
 

--- a/docs/quickstarts/react/support-more-roles.mdx
+++ b/docs/quickstarts/react/support-more-roles.mdx
@@ -47,7 +47,7 @@ In order to reference the data file in our policy, we’ll update our policy fil
 package asertodemo.GET.api.protected
 
 import input.policy.path
-import input.user.attributes.roles as user_roles
+import input.user.properties.roles as user_roles
 
 
 default allow = false


### PR DESCRIPTION
Still to do:  follow the Getting Started tutorials for "bring your own IDP", "ABAC policies", and "modify the policy" to ensure these still work.

There are repos that need to be updated, e.g. https://github.com/aserto-demo/aserto-react-and-node-with-conditional-rendering