### PR TITLE
updated sdk ordering and did some maintenance

### DIFF
--- a/docs/authorizer-guide/display-state-map.mdx
+++ b/docs/authorizer-guide/display-state-map.mdx
@@ -36,6 +36,6 @@ user. We call this map of maps a **display state map** and it looks like this:
 The Aserto [JavaScript SPA SDK](/docs/software-development-kits/javascript/spa) and
 [React.js SDK](/docs/software-development-kits/javascript/react) support this pattern. Each of these SDKs works together
 with other high-level language SDKs like the
-[Express.js](/docs/software-development-kits/javascript/express#displaystatemap-middleware) middleware to allow retrieving this
+[Node.js](/docs/software-development-kits/javascript/express#displaystatemap-middleware) middleware to allow retrieving this
 **display state map** when the user logs in (and/or reload it). This in turn can be used to instruct
 the UI on whether to render specific UI elements that correspond to these routes / permissions.

--- a/docs/software-development-kits/javascript/express.mdx
+++ b/docs/software-development-kits/javascript/express.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Express.js
+sidebar_label: Node.js
 title: Aserto SDKs - Node.js / Express.js - Installation and setup
 description: Aserto SDKs - Node.js / Express.js - Installing and using the Express.js SDK middleware
 ---

--- a/docs/software-development-kits/javascript/react.mdx
+++ b/docs/software-development-kits/javascript/react.mdx
@@ -15,7 +15,7 @@ the front-end typically wants to avoid displaying UI elements that allow users t
 Aserto addresses this problem by defining the [**display state map**](/docs/authorizer-guide/display-state-map) pattern.
 
 The Aserto React SDK works together with other high-level language SDKs like the
-[Express.js](/docs/software-development-kits/javascript/express#displayStateMap-middleware) to allow retrieving this
+[Node.js](/docs/software-development-kits/javascript/express#displaystatemap-middleware) to allow retrieving this
 **display state map** when the user logs in (and/or reload it). This in turn can be used to instruct
 the UI on whether to render specific UI elements that correspond to these routes / permissions.
 
@@ -169,7 +169,7 @@ console.log(displayStateMap)
 
 ### identity and setIdentity
 
-- `setIdentity` can be used to set the identity to pass as an `identity` HTTP header. It will override an `identity` header that is passed into `reload(headers)`. This is the preferred way to send an identity to the [displayStateMap](/docs/software-development-kits/javascript/express#displayStateMap-middleware) API, which can be used to override the Authorization header by the displayStateMap middleware.
+- `setIdentity` can be used to set the identity to pass as an `identity` HTTP header. It will override an `identity` header that is passed into `reload(headers)`. This is the preferred way to send an identity to the [displayStateMap](/docs/software-development-kits/javascript/express#displaystatemap-middleware) API, which can be used to override the Authorization header by the displayStateMap middleware.
 - `identity` will return the current identity (or undefined if it hasn't been set).
 
 ### getDisplayState('method, 'path')

--- a/docs/software-development-kits/javascript/spa.mdx
+++ b/docs/software-development-kits/javascript/spa.mdx
@@ -15,7 +15,7 @@ the front-end typically wants to avoid displaying UI elements that allow users t
 Aserto addresses this problem by defining the [**display state map**](/docs/authorizer-guide/display-state-map) pattern.
 
 The Aserto JavaScript SPA SDK works together with other high-level language SDKs like the
-[Express.js](/docs/software-development-kits/javascript/express#displaystatemap-middleware) to allow retrieving this
+[Node.js](/docs/software-development-kits/javascript/express#displaystatemap-middleware) to allow retrieving this
 **display state map** when the user logs in (and/or reload it). This in turn can be used to instruct
 the UI on whether to render specific UI elements that correspond to these routes / permissions.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -168,9 +168,27 @@ module.exports = {
           label: 'JavaScript',
           collapsed: false,
           items: [
+            'software-development-kits/javascript/express',
             'software-development-kits/javascript/react',
             'software-development-kits/javascript/spa',
-            'software-development-kits/javascript/express',
+          ],
+        },
+        {
+          type: 'category',
+          label: 'Go',
+          collapsed: false,
+          items: [
+            'software-development-kits/go/install',
+            'software-development-kits/go/authorizer',
+            {
+              type: 'category',
+              label: 'Middleware',
+              collapsed: false,
+              items: [
+                'software-development-kits/go/middleware-http',
+                'software-development-kits/go/middleware-grpc',
+              ],
+            },
           ],
         },
         {
@@ -193,20 +211,11 @@ module.exports = {
         },
         {
           type: 'category',
-          label: 'Go',
+          label: 'Java',
           collapsed: false,
           items: [
-            'software-development-kits/go/install',
-            'software-development-kits/go/authorizer',
-            {
-              type: 'category',
-              label: 'Middleware',
-              collapsed: false,
-              items: [
-                'software-development-kits/go/middleware-http',
-                'software-development-kits/go/middleware-grpc',
-              ],
-            },
+            'software-development-kits/java/grpc-bindings',
+            'software-development-kits/java/authorizer'
           ],
         },
         'software-development-kits/dotnetcore',
@@ -219,15 +228,6 @@ module.exports = {
             'software-development-kits/ruby/rails',
           ],
         },
-        {
-          type: 'category',
-          label: 'Java',
-          collapsed: false,
-          items: [
-            'software-development-kits/java/grpc-bindings',
-            'software-development-kits/java/authorizer'
-          ],
-        }
       ],
     },
     {

--- a/src/components/SdkPage/index.js
+++ b/src/components/SdkPage/index.js
@@ -14,7 +14,7 @@ const SdkPage = () => {
                         key={s.title}
                         title={s.title}
                         icon={s.icon}
-                        link={s.link}
+                        link={s.docs}
                         github={s.github}
                         docs={s.docs}
                     />

--- a/src/sdks.js
+++ b/src/sdks.js
@@ -1,5 +1,12 @@
 export default [
   {
+    title: 'Node.js',
+    icon: 'nodejs.svg',
+    link: 'https://expressjs.com',
+    github: 'https://github.com/aserto-dev/aserto-node',
+    docs: '/docs/software-development-kits/javascript/express',
+  },
+  {
     title: 'React.js',
     icon: 'react.svg',
     link: 'https://reactjs.org',
@@ -14,11 +21,11 @@ export default [
     docs: '/docs/software-development-kits/javascript/spa',
   },
   {
-    title: 'Express.js',
-    icon: 'nodejs.svg',
-    link: 'https://expressjs.com',
-    github: 'https://github.com/aserto-dev/express-jwt-aserto',
-    docs: '/docs/software-development-kits/javascript/express',
+    title: 'Go',
+    icon: 'go.svg',
+    link: 'https://go.dev/',
+    github: 'https://github.com/aserto-dev/aserto-go',
+    docs: '/docs/software-development-kits/go/install',
   },
   {
     title: 'Python',
@@ -31,8 +38,16 @@ export default [
     title: 'Flask',
     icon: 'flask.svg',
     link: 'https://flask.palletsprojects.com',
-    github: 'https://github.com/aserto-dev/aserto-python/tree/main/packages/flask-aserto',
+    github:
+      'https://github.com/aserto-dev/aserto-python/tree/main/packages/flask-aserto',
     docs: '/docs/software-development-kits/python/flask',
+  },
+  {
+    title: 'Java',
+    icon: 'java.svg',
+    link: 'https://www.java.com/en/',
+    github: 'https://github.com/aserto-dev/java-authorizer',
+    docs: '/docs/software-development-kits/java/authorizer',
   },
   {
     title: 'ASP.NET Core',
@@ -40,13 +55,6 @@ export default [
     link: 'https://dotnet.microsoft.com/apps/aspnet',
     github: 'https://github.com/aserto-dev/aserto-dotnet',
     docs: '/docs/software-development-kits/dotnetcore',
-  },
-  {
-    title: 'Go',
-    icon: 'go.svg',
-    link: 'https://go.dev/',
-    github: 'https://github.com/aserto-dev/aserto-go',
-    docs: '/docs/software-development-kits/go/install',
   },
   {
     title: 'Ruby',
@@ -62,11 +70,4 @@ export default [
     github: 'https://github.com/aserto-dev/aserto-rails',
     docs: '/docs/software-development-kits/ruby/rails',
   },
-  {
-    title: 'Java',
-    icon: 'java.svg',
-    link: 'https://www.java.com/en/',
-    github: 'https://github.com/aserto-dev/java-authorizer',
-    docs: '/docs/software-development-kits/java/authorizer',
-  }
 ]


### PR DESCRIPTION
a bit of SDK reordering and maintenance

* fixed wrong node.js SDK link
* Express.js -> Node.js
* reordered Java to be ahead of .net and ruby
* made it symmetric to the changes I made in the topaz docs
