### PR TITLE
helm chart documentation

### DIFF
--- a/docs/getting-started/self-hosted/helm-chart.mdx
+++ b/docs/getting-started/self-hosted/helm-chart.mdx
@@ -8,7 +8,7 @@ description: Deploy Self-Hosted Console to Kubernetes
 
 ## Helm Chart
 
-Aserto provides an official helm chart to deploy authorizer, directory, and console deployments to your kubernetes cluster.  For testing purposes you can start up a local kubernetes cluster using [minikube](https://minikube.sigs.k8s.io/docs/start/), or deploy to a remote cluster.
+Aserto provides an official helm chart to deploy an authorizer, directory, and a web console to your kubernetes cluster.  For testing purposes you can start up a local kubernetes cluster using [minikube](https://minikube.sigs.k8s.io/docs/start/), or deploy to a remote cluster.
 
 ### Usage
 Helm must be installed to use the charts. Please refer to Helm’s [documentation](https://helm.sh/docs/intro/install/) to get started.

--- a/docs/getting-started/self-hosted/helm-chart.mdx
+++ b/docs/getting-started/self-hosted/helm-chart.mdx
@@ -8,10 +8,10 @@ description: Deploy Self-Hosted Console to Kubernetes
 
 ## Helm Chart
 
-Aserto provides an official helm chart to deploy authorizer, directory, and console deployments to your kubernetes cluster.
+Aserto provides an official helm chart to deploy authorizer, directory, and console deployments to your kubernetes cluster.  For testing purposes you can start up a local kubernetes cluster using [minikube](https://minikube.sigs.k8s.io/docs/start/), or deploy to a remote cluster.
 
 ### Usage
-Helm must be installed to use the charts. Please refer to Helm’s documentation to get started.
+Helm must be installed to use the charts. Please refer to Helm’s [documentation](https://helm.sh/docs/intro/install/) to get started.
 
 Once Helm has been set up correctly, add the repo as follows:
 
@@ -33,8 +33,39 @@ To uninstall the chart:
 helm delete my-aserto
 ```
 
-## Using your own database
+### Connect to the Console
 
-The helm chart deploys a local postgres deployment by default.  To use your own database you can override configuration.
+For testing purposes you can access the self-hosted console by forwarding a port to the console-proxy pod.  Use this command to retrieve the pod name:
 
-values.yaml WIP
+```
+CONSOLE_POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=console-proxy,app.kubernetes.io/instance=my-aserto" -o jsonpath="{.items[0].metadata.name}")
+```
+
+Then start port forwarding to the server with:
+```
+kubectl --namespace default port-forward $CONSOLE_POD_NAME 8080:8080
+```
+
+For production installations you can install your own kubernetes ingress routes to direct traffic to the console, authorizer, and directory services.
+
+### Using your own database
+
+The helm chart deploys a local postgres deployment which is used by the directory by default.  This local database does not persist after the chart is uninstalled.  To use your own external database server you can override the default chart configuration via a `values.yaml` file.
+
+Create a `values.yaml` in a local folder.  Replace these values with your own.
+```yaml
+global:
+    postgresql:
+      localServerEnabled: false
+      auth:
+        postgresHost: postgresql.example.com
+        postgresUser: postgres
+        postgresPassword: directory
+        database: directory
+```
+Apply your values file with the -f flag when installing the chart:
+```bash
+helm install my-aserto aserto/self-hosted  -f values.yaml
+```
+
+Make sure that the database and database user you choose are already created, and that your kubernetes cluster has connectivity to the database server.

--- a/docs/getting-started/self-hosted/helm-chart.mdx
+++ b/docs/getting-started/self-hosted/helm-chart.mdx
@@ -1,0 +1,38 @@
+---
+sidebar_label: Deploy to Kubernetes
+title: Deploy Self-Hosted Console to Kubernetes
+description: Deploy Self-Hosted Console to Kubernetes
+---
+
+# Deploy Self-Hosted Console to Kubernetes via Helm Chart
+
+## Helm Chart
+
+### Usage
+Helm must be installed to use the charts. Please refer to Helm’s documentation to get started.
+
+Once Helm has been set up correctly, add the repo as follows:
+
+```bash
+helm repo add aserto https://charts.aserto.com
+```
+
+If you had already added this repo earlier, run `helm repo update` to retrieve the latest versions of the packages. You can then run `helm search repo aserto` to see the charts.
+
+To install the self-hosted chart:
+
+```bash
+helm install my-aserto aserto/self-hosted
+```
+
+To uninstall the chart:
+
+```bash
+helm delete my-aserto
+```
+
+## Using your own database
+
+The helm chart deploys a local postgres deployment by default.  To use your own database you can override configuration.
+
+values.yaml WIP

--- a/docs/getting-started/self-hosted/helm-chart.mdx
+++ b/docs/getting-started/self-hosted/helm-chart.mdx
@@ -4,9 +4,11 @@ title: Deploy Self-Hosted Console to Kubernetes
 description: Deploy Self-Hosted Console to Kubernetes
 ---
 
-# Deploy Self-Hosted Console to Kubernetes via Helm Chart
+# Deploy Self-Hosted Console to Kubernetes
 
 ## Helm Chart
+
+Aserto provides an official helm chart to deploy authorizer, directory, and console deployments to your kubernetes cluster.
 
 ### Usage
 Helm must be installed to use the charts. Please refer to Helm’s documentation to get started.

--- a/sidebars.js
+++ b/sidebars.js
@@ -45,6 +45,15 @@ module.exports = {
             'getting-started/peoplefinder/modify-the-policy',
           ],
         },
+
+        {
+          type: 'category',
+          label: 'Self-Hosted',
+          collapsed: false,
+          items: [
+            'getting-started/self-hosted/helm-chart'
+          ],
+        },
         {
           type: 'category',
           label: 'Explore ABAC Policies',


### PR DESCRIPTION
Add documentation under "Gettting Started" for installation on kubernetes via helm chart.

Looking for testing and feedback.

I could see this being its own section instead of under Getting Started.